### PR TITLE
datasource/ip4_nbr: add CIDR-based lookup via GetEntityByCIDR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ IMPROVEMENTS:
 * Replaced per-operation login/logout boilerplate with a `withClient` helper using defer for guaranteed session cleanup.
 * Removed scaffolding template comments and placeholder descriptions.
 * resource/bluecat_ip4_available_network: `ImportState` now accepts a BlueCat network ID instead of the non-functional passthrough on the placeholder ID.
+* datasource/bluecat_ip4_nbr: `address` is now optional. A new optional `cidr` attribute allows looking up an IPv4 network or block directly by CIDR notation using the BlueCat `GetEntityByCIDR` API. Exactly one of `address` or `cidr` must be set. Note that `cidr` lookups require `container_id` to be the direct parent container; `DHCP4Range` is not supported with `cidr` and will produce a plan-time error.
 * Updated Go to 1.25.0
 * Updated [terraform-plugin-framework](https://github.com/hashicorp/terraform-plugin-framework) to 1.19.0
 * Updated [terraform-plugin-framework-validators](https://github.com/hashicorp/terraform-plugin-framework-validators) to 0.19.0

--- a/docs/data-sources/ip4_nbr.md
+++ b/docs/data-sources/ip4_nbr.md
@@ -3,12 +3,12 @@
 page_title: "bluecat_ip4_nbr Data Source - bluecat"
 subcategory: ""
 description: |-
-  Data source to access the attributes of an IPv4 network, IPv4 Block, or DHCPv4 Range from an IPv4 address.
+  Data source to access the attributes of an IPv4 network, IPv4 Block, or DHCPv4 Range from an IPv4 address or CIDR. When using cidr, container_id must be the direct parent container; when using address, container_id can be any ancestor container.
 ---
 
 # bluecat_ip4_nbr (Data Source)
 
-Data source to access the attributes of an IPv4 network, IPv4 Block, or DHCPv4 Range from an IPv4 address.
+Data source to access the attributes of an IPv4 network, IPv4 Block, or DHCPv4 Range from an IPv4 address or CIDR. When using `cidr`, `container_id` must be the direct parent container; when using `address`, `container_id` can be any ancestor container.
 
 ## Example Usage
 
@@ -29,16 +29,19 @@ output "bluecat_network_name" {
 
 ### Required
 
-- `address` (String) IP address to find the IPv4 network, IPv4 Block, or DHCPv4 Range of.
 - `container_id` (Number) The object ID of a container that contains the specified IPv4 network, block, or range.
 - `type` (String) Must be "IP4Block", "IP4Network", "DHCP4Range", or "". "" will find the most specific container.
 
+### Optional
+
+- `address` (String) IP address to find the IPv4 network, IPv4 Block, or DHCPv4 Range of. Exactly one of `address` or `cidr` must be set.
+- `cidr` (String) The CIDR address of the IPv4 network or block to look up. Cannot be used when `type` is `DHCP4Range`. Exactly one of `address` or `cidr` must be set.
+
 ### Read-Only
 
-- `addresses_free` (Number) The number of addresses unallocated/free on the network.
-- `addresses_in_use` (Number) The number of addresses allocated/in use on the network.
+- `addresses_free` (Number) The number of addresses unallocated/free on the network. Calculated by fetching all child IP4Address objects; may be slow or inaccurate for large `IP4Block` ranges.
+- `addresses_in_use` (Number) The number of addresses allocated/in use on the network. Calculated by fetching all child IP4Address objects; may be slow or inaccurate for large `IP4Block` ranges.
 - `allow_duplicate_host` (String) Duplicate host names check.
-- `cidr` (String) The CIDR address of the IPv4 network.
 - `custom_properties` (Map of String) A map of all custom properties associated with the IPv4 network.
 - `default_domains` (Set of Number) The default domains for the network.
 - `default_view` (Number) The object id of the default DNS View for the network.

--- a/internal/provider/data_source_ip4_nbr.go
+++ b/internal/provider/data_source_ip4_nbr.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -21,6 +22,7 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ datasource.DataSource = &IP4NBRDataSource{}
+var _ datasource.DataSourceWithValidateConfig = &IP4NBRDataSource{}
 
 func NewIP4NBRDataSource() datasource.DataSource {
 	return &IP4NBRDataSource{}
@@ -66,7 +68,7 @@ func (d *IP4NBRDataSource) Metadata(ctx context.Context, req datasource.Metadata
 func (d *IP4NBRDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		// This description is used by the documentation generator and the language server.
-		MarkdownDescription: "Data source to access the attributes of an IPv4 network, IPv4 Block, or DHCPv4 Range from an IPv4 address.",
+		MarkdownDescription: "Data source to access the attributes of an IPv4 network, IPv4 Block, or DHCPv4 Range from an IPv4 address or CIDR. When using `cidr`, `container_id` must be the direct parent container; when using `address`, `container_id` can be any ancestor container.",
 
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
@@ -74,8 +76,14 @@ func (d *IP4NBRDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				Computed:            true,
 			},
 			"address": schema.StringAttribute{
-				MarkdownDescription: "IP address to find the IPv4 network, IPv4 Block, or DHCPv4 Range of.",
-				Required:            true,
+				MarkdownDescription: "IP address to find the IPv4 network, IPv4 Block, or DHCPv4 Range of. Exactly one of `address` or `cidr` must be set.",
+				Optional:            true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.Expressions{
+						path.MatchRoot("address"),
+						path.MatchRoot("cidr"),
+					}...),
+				},
 			},
 			"container_id": schema.Int64Attribute{
 				MarkdownDescription: "The object ID of a container that contains the specified IPv4 network, block, or range.",
@@ -89,11 +97,11 @@ func (d *IP4NBRDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				},
 			},
 			"addresses_free": schema.Int64Attribute{
-				MarkdownDescription: "The number of addresses unallocated/free on the network.",
+				MarkdownDescription: "The number of addresses unallocated/free on the network. Calculated by fetching all child IP4Address objects; may be slow or inaccurate for large `IP4Block` ranges.",
 				Computed:            true,
 			},
 			"addresses_in_use": schema.Int64Attribute{
-				MarkdownDescription: "The number of addresses allocated/in use on the network.",
+				MarkdownDescription: "The number of addresses allocated/in use on the network. Calculated by fetching all child IP4Address objects; may be slow or inaccurate for large `IP4Block` ranges.",
 				Computed:            true,
 			},
 			"allow_duplicate_host": schema.StringAttribute{
@@ -101,8 +109,15 @@ func (d *IP4NBRDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				Computed:            true,
 			},
 			"cidr": schema.StringAttribute{
-				MarkdownDescription: "The CIDR address of the IPv4 network.",
+				MarkdownDescription: "The CIDR address of the IPv4 network or block to look up. Cannot be used when `type` is `DHCP4Range`. Exactly one of `address` or `cidr` must be set.",
+				Optional:            true,
 				Computed:            true,
+				Validators: []validator.String{
+					stringvalidator.ExactlyOneOf(path.Expressions{
+						path.MatchRoot("address"),
+						path.MatchRoot("cidr"),
+					}...),
+				},
 			},
 			"custom_properties": schema.MapAttribute{
 				MarkdownDescription: "A map of all custom properties associated with the IPv4 network.",
@@ -175,6 +190,22 @@ func (d *IP4NBRDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 	}
 }
 
+func (d *IP4NBRDataSource) ValidateConfig(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	var data IP4NBRDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !data.CIDR.IsNull() && !data.CIDR.IsUnknown() && data.Type.ValueString() == "DHCP4Range" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("type"),
+			"Invalid type for CIDR lookup",
+			"GetEntityByCIDR does not support DHCP4Range. Use \"IP4Block\" or \"IP4Network\" when cidr is specified.",
+		)
+	}
+}
+
 func (d *IP4NBRDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
@@ -210,12 +241,30 @@ func (d *IP4NBRDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 		containerID := data.ContainerID.ValueInt64()
 		otype := data.Type.ValueString()
-		address := data.Address.ValueString()
 
-		ipRange, err := client.GetIPRangedByIP(containerID, otype, address)
-		if err != nil {
-			diags.AddError("Failed to get IP4 Networks by hint", err.Error())
-			return diags
+		var ipRange *gobam.APIEntity
+		var err error
+
+		if !data.Address.IsNull() && !data.Address.IsUnknown() {
+			ipRange, err = client.GetIPRangedByIP(containerID, otype, data.Address.ValueString())
+			if err != nil {
+				diags.AddError("Failed to get IP4 range by IP address", err.Error())
+				return diags
+			}
+			if *ipRange.Id == 0 {
+				diags.AddError("IP4 range not found", fmt.Sprintf("No IP4 range found containing address %s", data.Address.ValueString()))
+				return diags
+			}
+		} else {
+			ipRange, err = client.GetEntityByCIDR(containerID, data.CIDR.ValueString(), otype)
+			if err != nil {
+				diags.AddError("Failed to get IP4 range by CIDR", err.Error())
+				return diags
+			}
+			if *ipRange.Id == 0 {
+				diags.AddError("IP4 range not found", fmt.Sprintf("No IP4 range found for CIDR %s", data.CIDR.ValueString()))
+				return diags
+			}
 		}
 
 		data.ID = types.StringValue(strconv.FormatInt(*ipRange.Id, 10))
@@ -230,7 +279,11 @@ func (d *IP4NBRDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 			return diags
 		}
 
-		data.CIDR = networkProperties.cidr
+		if !networkProperties.cidr.IsNull() {
+			data.CIDR = networkProperties.cidr
+		}
+		// If cidr is still null (not in API response properties), the user-provided value
+		// in data.CIDR is preserved from the config — use it for address usage calculation.
 		data.Template = networkProperties.template
 		data.Gateway = networkProperties.gateway
 		data.DefaultDomains = networkProperties.defaultDomains
@@ -247,7 +300,7 @@ func (d *IP4NBRDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		data.LocationInherited = networkProperties.locationInherited
 		data.CustomProperties = networkProperties.customProperties
 
-		addressesInUse, addressesFree, err := getIP4NetworkAddressUsage(*ipRange.Id, networkProperties.cidr.ValueString(), client)
+		addressesInUse, addressesFree, err := getIP4NetworkAddressUsage(*ipRange.Id, data.CIDR.ValueString(), client)
 		if err != nil {
 			diags.AddError("Error calculating network usage", err.Error())
 			return diags

--- a/internal/provider/data_source_ip4_nbr.go
+++ b/internal/provider/data_source_ip4_nbr.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"context"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
 
@@ -482,13 +481,16 @@ func parseIP4NetworkProperties(properties string) (ip4NetworkProperties, diag.Di
 func getIP4NetworkAddressUsage(id int64, cidr string, client gobam.ProteusAPI) (int64, int64, error) {
 	parts := strings.Split(cidr, "/")
 	if len(parts) != 2 {
-		return 0, 0, fmt.Errorf("error parsing netmask from cidr string %q: expected format a.b.c.d/prefix", cidr)
+		return 0, 0, fmt.Errorf("error parsing prefix from cidr string %q: expected format a.b.c.d/prefix", cidr)
 	}
-	netmask, err := strconv.ParseFloat(parts[1], 64)
+	prefix, err := strconv.ParseInt(parts[1], 10, 64)
 	if err != nil {
-		return 0, 0, fmt.Errorf("error parsing netmask from cidr string %q: %w", cidr, err)
+		return 0, 0, fmt.Errorf("error parsing prefix from cidr string %q: %w", cidr, err)
 	}
-	addressCount := int(math.Pow(2, (32 - netmask)))
+	if prefix < 0 || prefix > 32 {
+		return 0, 0, fmt.Errorf("invalid prefix length %d in cidr string %q: must be between 0 and 32", prefix, cidr)
+	}
+	addressCount := 1 << (32 - prefix)
 
 	resp, err := client.GetEntities(id, "IP4Address", 0, addressCount)
 	if err != nil {

--- a/internal/provider/data_source_ip4_nbr.go
+++ b/internal/provider/data_source_ip4_nbr.go
@@ -490,15 +490,20 @@ func getIP4NetworkAddressUsage(id int64, cidr string, client gobam.ProteusAPI) (
 	if prefix < 0 || prefix > 32 {
 		return 0, 0, fmt.Errorf("invalid prefix length %d in cidr string %q: must be between 0 and 32", prefix, cidr)
 	}
-	addressCount := 1 << (32 - prefix)
+	addressCount := uint64(1) << uint(32-prefix)
+	maxInt := int(^uint(0) >> 1)
+	if addressCount > uint64(maxInt) {
+		return 0, 0, fmt.Errorf("cidr %q contains %d addresses, which is too large to enumerate on this build", cidr, addressCount)
+	}
+	addressCountInt := int(addressCount)
 
-	resp, err := client.GetEntities(id, "IP4Address", 0, addressCount)
+	resp, err := client.GetEntities(id, "IP4Address", 0, addressCountInt)
 	if err != nil {
 		return 0, 0, err
 	}
 
 	addressesInUse := int64(len(resp.Item))
-	addressesFree := int64(addressCount) - addressesInUse
+	addressesFree := int64(addressCountInt) - addressesInUse
 
 	return addressesInUse, addressesFree, nil
 }

--- a/internal/provider/data_source_ip4_nbr.go
+++ b/internal/provider/data_source_ip4_nbr.go
@@ -112,12 +112,6 @@ func (d *IP4NBRDataSource) Schema(ctx context.Context, req datasource.SchemaRequ
 				MarkdownDescription: "The CIDR address of the IPv4 network or block to look up. Cannot be used when `type` is `DHCP4Range`. Exactly one of `address` or `cidr` must be set.",
 				Optional:            true,
 				Computed:            true,
-				Validators: []validator.String{
-					stringvalidator.ExactlyOneOf(path.Expressions{
-						path.MatchRoot("address"),
-						path.MatchRoot("cidr"),
-					}...),
-				},
 			},
 			"custom_properties": schema.MapAttribute{
 				MarkdownDescription: "A map of all custom properties associated with the IPv4 network.",
@@ -245,7 +239,11 @@ func (d *IP4NBRDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		var ipRange *gobam.APIEntity
 		var err error
 
-		if !data.Address.IsNull() && !data.Address.IsUnknown() {
+		if !data.Address.IsNull() {
+			if data.Address.IsUnknown() {
+				diags.AddError("Address value is not yet known", "The address attribute must be a known value at read time.")
+				return diags
+			}
 			ipRange, err = client.GetIPRangedByIP(containerID, otype, data.Address.ValueString())
 			if err != nil {
 				diags.AddError("Failed to get IP4 range by IP address", err.Error())
@@ -256,6 +254,10 @@ func (d *IP4NBRDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 				return diags
 			}
 		} else {
+			if data.CIDR.IsNull() || data.CIDR.IsUnknown() {
+				diags.AddError("CIDR value is not yet known", "The cidr attribute must be a known value at read time.")
+				return diags
+			}
 			ipRange, err = client.GetEntityByCIDR(containerID, data.CIDR.ValueString(), otype)
 			if err != nil {
 				diags.AddError("Failed to get IP4 range by CIDR", err.Error())
@@ -478,10 +480,13 @@ func parseIP4NetworkProperties(properties string) (ip4NetworkProperties, diag.Di
 }
 
 func getIP4NetworkAddressUsage(id int64, cidr string, client gobam.ProteusAPI) (int64, int64, error) {
-
-	netmask, err := strconv.ParseFloat(strings.Split(cidr, "/")[1], 64)
+	parts := strings.Split(cidr, "/")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("error parsing netmask from cidr string %q: expected format a.b.c.d/prefix", cidr)
+	}
+	netmask, err := strconv.ParseFloat(parts[1], 64)
 	if err != nil {
-		return 0, 0, fmt.Errorf("error parsing netmask from cidr string")
+		return 0, 0, fmt.Errorf("error parsing netmask from cidr string %q: %w", cidr, err)
 	}
 	addressCount := int(math.Pow(2, (32 - netmask)))
 

--- a/internal/provider/data_source_ip4_nbr_test.go
+++ b/internal/provider/data_source_ip4_nbr_test.go
@@ -44,6 +44,7 @@ func TestAccIP4NBRDataSourceCIDR(t *testing.T) {
 
 func TestAccIP4NBRDataSourceCIDRRangeError(t *testing.T) {
 	resource.UnitTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_ip4_nbr_test.go
+++ b/internal/provider/data_source_ip4_nbr_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -22,6 +23,38 @@ func TestAccIP4NBRDataSource(t *testing.T) {
 	})
 }
 
+func TestAccIP4NBRDataSourceCIDR(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccCheckEnvVars(t, "TF_VAR_config_name", "TF_VAR_ip4_address")
+		},
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIP4NBRDataSourceCIDRConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrWith("data.bluecat_ip4_nbr.test_cidr", "id", validateObjectID),
+					// both lookups should resolve to the same network
+					resource.TestCheckResourceAttrPair("data.bluecat_ip4_nbr.test_cidr", "id", "data.bluecat_ip4_nbr.by_address", "id"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccIP4NBRDataSourceCIDRRangeError(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccIP4NBRDataSourceCIDRRangeConfig,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Invalid type for CIDR lookup"),
+			},
+		},
+	})
+}
+
 const testAccIP4NBRDataSourceConfig = testAccEntityDataSourceConfig + `
 variable "ip4_address" {
 	type = string
@@ -32,4 +65,39 @@ data "bluecat_ip4_nbr" "test" {
 	address      = var.ip4_address
 	type         = "IP4Network"
   }
+`
+
+const testAccIP4NBRDataSourceCIDRConfig = testAccEntityDataSourceConfig + `
+variable "ip4_address" {
+	type = string
+}
+
+# Look up the network by address to discover its CIDR
+data "bluecat_ip4_nbr" "by_address" {
+	container_id = data.bluecat_entity.config.id
+	address      = var.ip4_address
+	type         = "IP4Network"
+}
+
+# Look up the parent block by address to use as container_id for the CIDR lookup
+data "bluecat_ip4_nbr" "parent_block" {
+	container_id = data.bluecat_entity.config.id
+	address      = var.ip4_address
+	type         = "IP4Block"
+}
+
+# Look up the same network by CIDR using the direct parent block
+data "bluecat_ip4_nbr" "test_cidr" {
+	container_id = data.bluecat_ip4_nbr.parent_block.id
+	cidr         = data.bluecat_ip4_nbr.by_address.cidr
+	type         = "IP4Network"
+}
+`
+
+const testAccIP4NBRDataSourceCIDRRangeConfig = `
+data "bluecat_ip4_nbr" "test_range_error" {
+	container_id = 1
+	cidr         = "10.0.0.0/24"
+	type         = "DHCP4Range"
+}
 `


### PR DESCRIPTION
Fixes #125

## Changes

- `address` is now optional (was required)
- `cidr` is now optional+computed (was computed-only); when provided, uses `GetEntityByCIDR` to look up the network or block directly by CIDR notation
- Exactly one of `address` or `cidr` must be set — enforced at plan time via `ExactlyOneOf` schema validators
- `DHCP4Range` combined with `cidr` produces a plan-time error via `ValidateConfig`, since `GetEntityByCIDR` does not support range objects
- Added not-found guards (id == 0) for both lookup paths with clear error messages
- Updated `addresses_free` and `addresses_in_use` descriptions to note the performance caveat for large `IP4Block` ranges

## Notes

- When using `cidr`, `container_id` must be the **direct parent** container. The `GetEntityByCIDR` API does not traverse the hierarchy the way `GetIPRangedByIP` does.
- Acceptance test `TestAccIP4NBRDataSourceCIDR` chains three lookups to avoid needing extra env vars: address→network (discovers CIDR), address→block (discovers direct parent ID), then CIDR lookup against that parent.